### PR TITLE
fix: update bash conditionals for POSIX compatibility

### DIFF
--- a/.github/workflows/reusable-pr-approved.yml
+++ b/.github/workflows/reusable-pr-approved.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Extract PR Information
         id: pr-info
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
             # PR was merged
             PR_NUMBER="${{ github.event.pull_request.number }}"
             PR_TITLE="${{ github.event.pull_request.title }}"
@@ -133,7 +133,7 @@ jobs:
           
           # Check if type should be in release notes
           RELEASE_TYPES="${{ inputs.release_note_types }}"
-          if [[ ",$RELEASE_TYPES," == *",$TYPE,"* ]] || [ "${{ steps.pr-info.outputs.breaking_change }}" == "true" ]; then
+          if [[ ",$RELEASE_TYPES," == *",$TYPE,"* ]] || [ "${{ steps.pr-info.outputs.breaking_change }}" = "true" ]; then
             echo "include_in_release=true" >> $GITHUB_OUTPUT
           else
             echo "include_in_release=false" >> $GITHUB_OUTPUT
@@ -199,7 +199,7 @@ jobs:
               ;;
           esac
           
-          if [ "$BREAKING" == "true" ]; then
+          if [ "$BREAKING" = "true" ]; then
             CATEGORY="### ⚠️ BREAKING CHANGES"
           fi
           


### PR DESCRIPTION
## Summary
- Fixed bash syntax errors in the reusable-pr-approved.yml workflow
- Replaced `==` with `=` in single bracket tests for POSIX compatibility
- This resolves the error: "bash: line 91: unexpected token `==', conditional binary operator expected"

## Context
The workflow was failing in post-merge automation steps due to non-POSIX bash syntax. This was a non-critical failure that didn't affect the core merge functionality but prevented:
- Post-merge PR information extraction
- Release notes generation
- Contributor thanks messages

## Changes Made
Updated three bash conditionals from `==` to `=` in single bracket tests:
1. Line 91: Event name check
2. Line 136: Breaking change check within release notes condition
3. Line 202: Breaking change category assignment

Note: Double bracket tests `[[ ]]` correctly retain `==` as they are bash-specific.

## Test Plan
- [x] Verified syntax changes are correct
- [x] Confirmed all single bracket tests now use POSIX-compliant `=`
- [x] Double bracket tests appropriately keep `==` for pattern matching
- [ ] Workflow will be tested on next PR merge

Fixes #9

🤖 Generated with [Claude Code](https://claude.ai/code)